### PR TITLE
patches: Add 0102 to fix ffmpeg-vaapi transcode memory out

### DIFF
--- a/patches/0102-fftools-ffmpeg_dec-Don-t-keep-sending-frame-to-filte.patch
+++ b/patches/0102-fftools-ffmpeg_dec-Don-t-keep-sending-frame-to-filte.patch
@@ -1,0 +1,41 @@
+From 592a2cb414282b1e528d45d867dfb5371c9f4946 Mon Sep 17 00:00:00 2001
+From: Fei Wang <fei.w.wang@intel.com>
+Date: Mon, 26 Jun 2023 11:34:09 +0800
+Subject: [PATCH] fftools/ffmpeg_dec: Don't keep sending frame to filters in
+ flushing
+
+Filter may has a limited frame pool size. Do not always send frame to
+filters without reaping.
+
+Fix the regression of commit 5fa00b38e6.
+
+Example cmd:
+$ ffmpeg -threads 20 -init_hw_device vaapi=hw:/dev/dri/renderD128   \
+-hwaccel_output_format vaapi -hwaccel vaapi -i avc_1080P.mp4        \
+-vf 'scale_vaapi=w=720:h=480' -f null -
+
+Signed-off-by: Fei Wang <fei.w.wang@intel.com>
+---
+ fftools/ffmpeg_dec.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/fftools/ffmpeg_dec.c b/fftools/ffmpeg_dec.c
+index 85bf8dc536..a7ae51fed2 100644
+--- a/fftools/ffmpeg_dec.c
++++ b/fftools/ffmpeg_dec.c
+@@ -803,6 +803,12 @@ int dec_packet(InputStream *ist, const AVPacket *pkt, int no_eof)
+         av_frame_unref(d->frame);
+         if (ret < 0)
+             goto finish;
++
++        // During flushing, break out to reap filter once send a frame to filters to
++        // avoid drain out filter's output frame pool. Especially for HW filters which
++        // always have a limited frame pool size.
++        if (!pkt)
++            return 0;
+     }
+ 
+ finish:
+-- 
+2.25.1
+


### PR DESCRIPTION
$ ffmpeg -threads 20 -v verbose -init_hw_device vaapi=hw:/dev/dri/renderD128 \
-hwaccel_output_format vaapi -hwaccel vaapi -i avc.mp4                       \
-vf 'scale_vaapi=w=720:h=480' -f null -

[vf#0:0 @ 0x559fa1faba00] Error while filtering: Cannot allocate memory