### PR TITLE
Update submodule and patchset

### DIFF
--- a/patches/0034-FFmpeg-vaapi-HEVC-SCC-encode.patch
+++ b/patches/0034-FFmpeg-vaapi-HEVC-SCC-encode.patch
@@ -1,7 +1,7 @@
-From c0ce9dea1d1515f2ac918687109c6a6dbe2fb0c8 Mon Sep 17 00:00:00 2001
+From a4a3068e61c3e209834f66ebd579b974ac520efe Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Sun, 18 Oct 2020 16:15:37 -0400
-Subject: [PATCH] FFmpeg vaapi HEVC SCC encode.
+Subject: [PATCH 06/40] FFmpeg vaapi HEVC SCC encode.
 
 Depend on 0008 hevc low power enable patch.
 
@@ -23,7 +23,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 43 insertions(+), 4 deletions(-)
 
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index aa7e532f9a..08c7f431f9 100644
+index efa59aecf5..060e318c99 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -341,8 +341,9 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
@@ -33,7 +33,7 @@ index aa7e532f9a..08c7f431f9 100644
 -    ptl->general_intra_constraint_flag = ctx->gop_size == 1;
      ptl->general_one_picture_only_constraint_flag = 0;
 +    ptl->general_intra_constraint_flag =
-+        (avctx->profile == FF_PROFILE_HEVC_SCC) ? 0 : ctx->gop_size == 1;
++        (avctx->profile == AV_PROFILE_HEVC_SCC) ? 0 : ctx->gop_size == 1;
  
      ptl->general_lower_bit_rate_constraint_flag = 1;
  
@@ -41,7 +41,7 @@ index aa7e532f9a..08c7f431f9 100644
      vui->log2_max_mv_length_horizontal = 15;
      vui->log2_max_mv_length_vertical   = 15;
  
-+    if (avctx->profile == FF_PROFILE_HEVC_SCC) {
++    if (avctx->profile == AV_PROFILE_HEVC_SCC) {
 +        sps->sps_extension_present_flag = 1;
 +        sps->sps_scc_extension_flag = 1;
 +        sps->sps_curr_pic_ref_enabled_flag = 1;
@@ -56,7 +56,7 @@ index aa7e532f9a..08c7f431f9 100644
  
      pps->pps_loop_filter_across_slices_enabled_flag = 1;
  
-+    if (avctx->profile == FF_PROFILE_HEVC_SCC) {
++    if (avctx->profile == AV_PROFILE_HEVC_SCC) {
 +        pps->pps_extension_present_flag = 1;
 +        pps->pps_scc_extension_flag =1;
 +        pps->pps_curr_pic_ref_enabled_flag = 1;
@@ -95,7 +95,7 @@ index aa7e532f9a..08c7f431f9 100644
 -        sh->num_ref_idx_active_override_flag = 0;
 -        sh->num_ref_idx_l0_active_minus1 = pps->num_ref_idx_l0_default_active_minus1;
 +
-+        if (avctx->profile == FF_PROFILE_HEVC_SCC) {
++        if (avctx->profile == AV_PROFILE_HEVC_SCC) {
 +            sh->num_ref_idx_active_override_flag = 1;
 +            sh->num_ref_idx_l0_active_minus1 = pps->num_ref_idx_l0_default_active_minus1 + 1;
 +        } else {
@@ -117,26 +117,26 @@ index aa7e532f9a..08c7f431f9 100644
  
          .luma_log2_weight_denom         = sh->luma_log2_weight_denom,
 @@ -1304,6 +1336,12 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
-     { FF_PROFILE_HEVC_REXT,     8, 3, 0, 0, VAProfileHEVCMain444 },
-     { FF_PROFILE_HEVC_REXT,    10, 3, 0, 0, VAProfileHEVCMain444_10 },
-     { FF_PROFILE_HEVC_REXT,    12, 3, 0, 0, VAProfileHEVCMain444_12 },
-+    { FF_PROFILE_HEVC_SCC,      8, 3, 1, 1, VAProfileHEVCSccMain    },
-+    { FF_PROFILE_HEVC_SCC,     10, 3, 1, 1, VAProfileHEVCSccMain10  },
-+    { FF_PROFILE_HEVC_SCC,      8, 3, 0, 0, VAProfileHEVCSccMain444 },
+     { AV_PROFILE_HEVC_REXT,     8, 3, 0, 0, VAProfileHEVCMain444 },
+     { AV_PROFILE_HEVC_REXT,    10, 3, 0, 0, VAProfileHEVCMain444_10 },
+     { AV_PROFILE_HEVC_REXT,    12, 3, 0, 0, VAProfileHEVCMain444_12 },
++    { AV_PROFILE_HEVC_SCC,      8, 3, 1, 1, VAProfileHEVCSccMain    },
++    { AV_PROFILE_HEVC_SCC,     10, 3, 1, 1, VAProfileHEVCSccMain10  },
++    { AV_PROFILE_HEVC_SCC,      8, 3, 0, 0, VAProfileHEVCSccMain444 },
 +#endif
 +#if VA_CHECK_VERSION(1, 9, 0)
-+    { FF_PROFILE_HEVC_SCC,     10, 3, 0, 0, VAProfileHEVCSccMain444_10 },
++    { AV_PROFILE_HEVC_SCC,     10, 3, 0, 0, VAProfileHEVCSccMain444_10 },
  #endif
-     { FF_PROFILE_UNKNOWN }
+     { AV_PROFILE_UNKNOWN }
  };
 @@ -1402,6 +1440,7 @@ static const AVOption vaapi_encode_h265_options[] = {
-     { PROFILE("main",               FF_PROFILE_HEVC_MAIN) },
-     { PROFILE("main10",             FF_PROFILE_HEVC_MAIN_10) },
-     { PROFILE("rext",               FF_PROFILE_HEVC_REXT) },
-+    { PROFILE("scc",                FF_PROFILE_HEVC_SCC) },
+     { PROFILE("main",               AV_PROFILE_HEVC_MAIN) },
+     { PROFILE("main10",             AV_PROFILE_HEVC_MAIN_10) },
+     { PROFILE("rext",               AV_PROFILE_HEVC_REXT) },
++    { PROFILE("scc",                AV_PROFILE_HEVC_SCC) },
  #undef PROFILE
  
      { "tier", "Set tier (general_tier_flag)",
 -- 
-2.25.1
+2.34.1
 

--- a/patches/0086-avcodec-add-D3D12VA-hardware-accelerated-HEVC-decodi.patch
+++ b/patches/0086-avcodec-add-D3D12VA-hardware-accelerated-HEVC-decodi.patch
@@ -1,7 +1,7 @@
-From 00928c8750ca1ddee31b070885e21b16423c4aa4 Mon Sep 17 00:00:00 2001
+From c6d8b90cb91599065c491ed8bf73b1f6fe0430fd Mon Sep 17 00:00:00 2001
 From: Wu Jianhua <toqsxw@outlook.com>
 Date: Sat, 17 Dec 2022 02:14:16 +0800
-Subject: [PATCH 03/19] avcodec: add D3D12VA hardware accelerated HEVC decoding
+Subject: [PATCH 24/40] avcodec: add D3D12VA hardware accelerated HEVC decoding
 
 The command below is how to enable d3d12va:
 ffmpeg -hwaccel d3d12va -i input.mp4 output.mp4
@@ -33,10 +33,10 @@ index b381838308..efcac1b434 100755
  hevc_dxva2_hwaccel_select="hevc_decoder"
  hevc_nvdec_hwaccel_deps="nvdec"
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index a7808937ce..eaebfc27cd 100644
+index 96d832ad54..1af623f631 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1009,6 +1009,7 @@ OBJS-$(CONFIG_H264_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
+@@ -1010,6 +1010,7 @@ OBJS-$(CONFIG_H264_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
  OBJS-$(CONFIG_H264_VULKAN_HWACCEL)        += vulkan_decode.o vulkan_h264.o
  OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
@@ -46,7 +46,7 @@ index a7808937ce..eaebfc27cd 100644
  OBJS-$(CONFIG_HEVC_VAAPI_HWACCEL)         += vaapi_hevc.o h265_profile_level.o
 diff --git a/libavcodec/d3d12va_hevc.c b/libavcodec/d3d12va_hevc.c
 new file mode 100644
-index 0000000000..4f6640be2f
+index 0000000000..d5dc02b8c5
 --- /dev/null
 +++ b/libavcodec/d3d12va_hevc.c
 @@ -0,0 +1,211 @@
@@ -228,15 +228,15 @@ index 0000000000..4f6640be2f
 +    D3D12VADecodeContext *ctx = D3D12VA_DECODE_CONTEXT(avctx);
 +
 +    switch (avctx->profile) {
-+    case FF_PROFILE_HEVC_MAIN_10:
++    case AV_PROFILE_HEVC_MAIN_10:
 +        ctx->cfg.DecodeProfile = D3D12_VIDEO_DECODE_PROFILE_HEVC_MAIN10;
 +        break;
 +
-+    case FF_PROFILE_HEVC_MAIN_STILL_PICTURE:
++    case AV_PROFILE_HEVC_MAIN_STILL_PICTURE:
 +        av_log(avctx, AV_LOG_ERROR, "D3D12 doesn't support PROFILE_HEVC_MAIN_STILL_PICTURE!\n");
 +        return AVERROR(EINVAL);
 +
-+    case FF_PROFILE_HEVC_MAIN:
++    case AV_PROFILE_HEVC_MAIN:
 +    default:
 +        ctx->cfg.DecodeProfile = D3D12_VIDEO_DECODE_PROFILE_HEVC_MAIN;
 +        break;
@@ -315,7 +315,7 @@ index e66e2c9769..f06ea75c60 100644
 +
  #endif /* AVCODEC_DXVA2_INTERNAL_H */
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index 91dbd24716..d91360b5ad 100644
+index 2253edc28b..2d34407930 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -402,6 +402,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
@@ -346,7 +346,7 @@ index 91dbd24716..d91360b5ad 100644
  #if CONFIG_HEVC_VAAPI_HWACCEL
          *fmt++ = AV_PIX_FMT_VAAPI;
  #endif
-@@ -3715,6 +3722,9 @@ const FFCodec ff_hevc_decoder = {
+@@ -3718,6 +3725,9 @@ const FFCodec ff_hevc_decoder = {
  #if CONFIG_HEVC_D3D11VA2_HWACCEL
                                 HWACCEL_D3D11VA2(hevc),
  #endif
@@ -369,5 +369,5 @@ index 90b8beb0f5..6b71919b0a 100644
  extern const struct FFHWAccel ff_hevc_nvdec_hwaccel;
  extern const struct FFHWAccel ff_hevc_vaapi_hwaccel;
 -- 
-2.41.0.windows.1
+2.34.1
 

--- a/patches/0087-avcodec-add-D3D12VA-hardware-accelerated-VP9-decodin.patch
+++ b/patches/0087-avcodec-add-D3D12VA-hardware-accelerated-VP9-decodin.patch
@@ -1,7 +1,7 @@
-From 97a614d4d94beeb2a4cc61ee4715723f805d6846 Mon Sep 17 00:00:00 2001
+From 389f7d01f226dc4110823cea63ff65b7ac58e89a Mon Sep 17 00:00:00 2001
 From: Wu Jianhua <toqsxw@outlook.com>
 Date: Sat, 17 Dec 2022 02:24:45 +0800
-Subject: [PATCH 04/19] avcodec: add D3D12VA hardware accelerated VP9 decoding
+Subject: [PATCH 25/40] avcodec: add D3D12VA hardware accelerated VP9 decoding
 
 The command below is how to enable d3d12va:
 ffmpeg -hwaccel d3d12va -i input.mp4 output.mp4
@@ -33,10 +33,10 @@ index efcac1b434..8e0cc23062 100755
  vp9_dxva2_hwaccel_select="vp9_decoder"
  vp9_nvdec_hwaccel_deps="nvdec"
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index eaebfc27cd..f0b9bdb9e6 100644
+index 1af623f631..b597684cff 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1041,6 +1041,7 @@ OBJS-$(CONFIG_VP8_NVDEC_HWACCEL)          += nvdec_vp8.o
+@@ -1042,6 +1042,7 @@ OBJS-$(CONFIG_VP8_NVDEC_HWACCEL)          += nvdec_vp8.o
  OBJS-$(CONFIG_VP8_VAAPI_HWACCEL)          += vaapi_vp8.o
  OBJS-$(CONFIG_VP9_D3D11VA_HWACCEL)        += dxva2_vp9.o
  OBJS-$(CONFIG_VP9_DXVA2_HWACCEL)          += dxva2_vp9.o
@@ -46,7 +46,7 @@ index eaebfc27cd..f0b9bdb9e6 100644
  OBJS-$(CONFIG_VP9_VDPAU_HWACCEL)          += vdpau_vp9.o
 diff --git a/libavcodec/d3d12va_vp9.c b/libavcodec/d3d12va_vp9.c
 new file mode 100644
-index 0000000000..6ff0c5400d
+index 0000000000..284e634b28
 --- /dev/null
 +++ b/libavcodec/d3d12va_vp9.c
 @@ -0,0 +1,176 @@
@@ -195,13 +195,13 @@ index 0000000000..6ff0c5400d
 +    D3D12VADecodeContext *ctx = D3D12VA_DECODE_CONTEXT(avctx);
 +
 +    switch (avctx->profile) {
-+    case FF_PROFILE_VP9_2:
-+    case FF_PROFILE_VP9_3:
++    case AV_PROFILE_VP9_2:
++    case AV_PROFILE_VP9_3:
 +        ctx->cfg.DecodeProfile = D3D12_VIDEO_DECODE_PROFILE_VP9_10BIT_PROFILE2;
 +        break;
 +
-+    case FF_PROFILE_VP9_0:
-+    case FF_PROFILE_VP9_1:
++    case AV_PROFILE_VP9_0:
++    case AV_PROFILE_VP9_1:
 +    default:
 +        ctx->cfg.DecodeProfile = D3D12_VIDEO_DECODE_PROFILE_VP9;
 +        break;
@@ -310,5 +310,5 @@ index 89f7549ef0..7b6e5e7c71 100644
                                 HWACCEL_NVDEC(vp9),
  #endif
 -- 
-2.41.0.windows.1
+2.34.1
 

--- a/patches/0088-avcodec-add-D3D12VA-hardware-accelerated-AV1-decodin.patch
+++ b/patches/0088-avcodec-add-D3D12VA-hardware-accelerated-AV1-decodin.patch
@@ -1,7 +1,7 @@
-From 2fc1aef19e8242f3742908e8c68d8bf266ca891d Mon Sep 17 00:00:00 2001
+From d1cb05259d903a28c606a6b2fac45befa5b46c82 Mon Sep 17 00:00:00 2001
 From: Wu Jianhua <toqsxw@outlook.com>
 Date: Sat, 17 Dec 2022 02:30:29 +0800
-Subject: [PATCH 05/19] avcodec: add D3D12VA hardware accelerated AV1 decoding
+Subject: [PATCH 26/40] avcodec: add D3D12VA hardware accelerated AV1 decoding
 
 The command below is how to enable d3d12va:
 ffmpeg -hwaccel d3d12va -i input.mp4 output.mp4
@@ -33,10 +33,10 @@ index 8e0cc23062..63167c6893 100755
  av1_dxva2_hwaccel_select="av1_decoder"
  av1_nvdec_hwaccel_deps="nvdec CUVIDAV1PICPARAMS"
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index f0b9bdb9e6..a4e6fd0ee1 100644
+index b597684cff..b877fead5e 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -992,6 +992,7 @@ OBJS-$(CONFIG_VULKAN)                     += vulkan.o vulkan_video.o
+@@ -993,6 +993,7 @@ OBJS-$(CONFIG_VULKAN)                     += vulkan.o vulkan_video.o
  
  OBJS-$(CONFIG_AV1_D3D11VA_HWACCEL)        += dxva2_av1.o
  OBJS-$(CONFIG_AV1_DXVA2_HWACCEL)          += dxva2_av1.o
@@ -45,18 +45,18 @@ index f0b9bdb9e6..a4e6fd0ee1 100644
  OBJS-$(CONFIG_AV1_VAAPI_HWACCEL)          += vaapi_av1.o
  OBJS-$(CONFIG_AV1_VDPAU_HWACCEL)          += vdpau_av1.o
 diff --git a/libavcodec/av1dec.c b/libavcodec/av1dec.c
-index 03283ab064..96e2c8febb 100644
+index 8f9c2dfefb..980805e9fe 100644
 --- a/libavcodec/av1dec.c
 +++ b/libavcodec/av1dec.c
-@@ -449,6 +449,7 @@ static int get_pixel_format(AVCodecContext *avctx)
-     enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
+@@ -511,6 +511,7 @@ static int get_pixel_format(AVCodecContext *avctx)
+     enum AVPixelFormat pix_fmt = get_sw_pixel_format(avctx, seq);
  #define HWACCEL_MAX (CONFIG_AV1_DXVA2_HWACCEL + \
                       CONFIG_AV1_D3D11VA_HWACCEL * 2 + \
 +                     CONFIG_AV1_D3D12VA_HWACCEL + \
                       CONFIG_AV1_NVDEC_HWACCEL + \
                       CONFIG_AV1_VAAPI_HWACCEL + \
                       CONFIG_AV1_VDPAU_HWACCEL + \
-@@ -524,6 +525,9 @@ static int get_pixel_format(AVCodecContext *avctx)
+@@ -529,6 +530,9 @@ static int get_pixel_format(AVCodecContext *avctx)
          *fmtp++ = AV_PIX_FMT_D3D11VA_VLD;
          *fmtp++ = AV_PIX_FMT_D3D11;
  #endif
@@ -66,7 +66,7 @@ index 03283ab064..96e2c8febb 100644
  #if CONFIG_AV1_NVDEC_HWACCEL
          *fmtp++ = AV_PIX_FMT_CUDA;
  #endif
-@@ -545,6 +549,9 @@ static int get_pixel_format(AVCodecContext *avctx)
+@@ -550,6 +554,9 @@ static int get_pixel_format(AVCodecContext *avctx)
          *fmtp++ = AV_PIX_FMT_D3D11VA_VLD;
          *fmtp++ = AV_PIX_FMT_D3D11;
  #endif
@@ -76,7 +76,7 @@ index 03283ab064..96e2c8febb 100644
  #if CONFIG_AV1_NVDEC_HWACCEL
          *fmtp++ = AV_PIX_FMT_CUDA;
  #endif
-@@ -1534,6 +1541,9 @@ const FFCodec ff_av1_decoder = {
+@@ -1542,6 +1549,9 @@ const FFCodec ff_av1_decoder = {
  #if CONFIG_AV1_D3D11VA2_HWACCEL
          HWACCEL_D3D11VA2(av1),
  #endif
@@ -88,7 +88,7 @@ index 03283ab064..96e2c8febb 100644
  #endif
 diff --git a/libavcodec/d3d12va_av1.c b/libavcodec/d3d12va_av1.c
 new file mode 100644
-index 0000000000..4476f5bd8a
+index 0000000000..005619c39a
 --- /dev/null
 +++ b/libavcodec/d3d12va_av1.c
 @@ -0,0 +1,220 @@
@@ -266,7 +266,7 @@ index 0000000000..4476f5bd8a
 +
 +    int ret;
 +
-+    if (avctx->profile != FF_PROFILE_AV1_MAIN)
++    if (avctx->profile != AV_PROFILE_AV1_MAIN)
 +        return AVERROR(EINVAL);
 +
 +    ctx->cfg.DecodeProfile = D3D12_VIDEO_DECODE_PROFILE_AV1_PROFILE0;
@@ -364,5 +364,5 @@ index 1344b84326..1c4825f2fb 100644
  extern const struct FFHWAccel ff_av1_nvdec_hwaccel;
  extern const struct FFHWAccel ff_av1_vaapi_hwaccel;
 -- 
-2.41.0.windows.1
+2.34.1
 

--- a/patches/0091-avcodec-d3d12va_hevc-enable-allow_profile_mismatch-f.patch
+++ b/patches/0091-avcodec-d3d12va_hevc-enable-allow_profile_mismatch-f.patch
@@ -1,7 +1,7 @@
-From 16d35930fd8d25c8d5e84b96fd6dd29798095226 Mon Sep 17 00:00:00 2001
+From c881e5e828363d5fd32af1a3c6a2b077777b2fed Mon Sep 17 00:00:00 2001
 From: Tong Wu <tong1.wu@intel.com>
 Date: Thu, 18 May 2023 15:13:04 +0800
-Subject: [PATCH 08/19] avcodec/d3d12va_hevc: enable allow_profile_mismatch
+Subject: [PATCH 29/40] avcodec/d3d12va_hevc: enable allow_profile_mismatch
  flag for d3d12va msp profile
 
 Same as d3d11va, this flag enables main still picture profile for
@@ -14,13 +14,13 @@ Signed-off-by: Tong Wu <tong1.wu@intel.com>
  1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/d3d12va_hevc.c b/libavcodec/d3d12va_hevc.c
-index 4f6640be2f..1894fddb79 100644
+index d5dc02b8c5..14bdfb6f93 100644
 --- a/libavcodec/d3d12va_hevc.c
 +++ b/libavcodec/d3d12va_hevc.c
 @@ -181,8 +181,13 @@ static int d3d12va_hevc_decode_init(AVCodecContext *avctx)
          break;
  
-     case FF_PROFILE_HEVC_MAIN_STILL_PICTURE:
+     case AV_PROFILE_HEVC_MAIN_STILL_PICTURE:
 -        av_log(avctx, AV_LOG_ERROR, "D3D12 doesn't support PROFILE_HEVC_MAIN_STILL_PICTURE!\n");
 -        return AVERROR(EINVAL);
 +        if (avctx->hwaccel_flags & AV_HWACCEL_FLAG_ALLOW_PROFILE_MISMATCH) {
@@ -31,8 +31,8 @@ index 4f6640be2f..1894fddb79 100644
 +            return AVERROR(EINVAL);
 +        }
  
-     case FF_PROFILE_HEVC_MAIN:
+     case AV_PROFILE_HEVC_MAIN:
      default:
 -- 
-2.41.0.windows.1
+2.34.1
 

--- a/patches/0098-lavc-av1-Add-common-code-and-unit-test-for-level-han.patch
+++ b/patches/0098-lavc-av1-Add-common-code-and-unit-test-for-level-han.patch
@@ -1,7 +1,7 @@
-From 7944c63c708b586f79374b48ea70557370d9f9f1 Mon Sep 17 00:00:00 2001
+From e982e79ab64d679adcc505026811bf82ee659ddc Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Tue, 14 Mar 2023 10:21:24 +0800
-Subject: [PATCH 1/4] lavc/av1: Add common code and unit test for level
+Subject: [PATCH 36/40] lavc/av1: Add common code and unit test for level
  handling
 
 Signed-off-by: Fei Wang <fei.w.wang@intel.com>
@@ -10,18 +10,18 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  libavcodec/av1_profile_level.c |  92 ++++++++++++++++++++++++
  libavcodec/av1_profile_level.h |  58 +++++++++++++++
  libavcodec/tests/.gitignore    |   1 +
- libavcodec/tests/av1_levels.c  | 124 +++++++++++++++++++++++++++++++++
+ libavcodec/tests/av1_levels.c  | 125 +++++++++++++++++++++++++++++++++
  tests/fate/libavcodec.mak      |   5 ++
- 6 files changed, 281 insertions(+)
+ 6 files changed, 282 insertions(+)
  create mode 100644 libavcodec/av1_profile_level.c
  create mode 100644 libavcodec/av1_profile_level.h
  create mode 100644 libavcodec/tests/av1_levels.c
 
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 6e0c91eb14..b3f310abf6 100644
+index 735268f57a..02c84d5f33 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1330,6 +1330,7 @@ TESTPROGS-$(CONFIG_H264_METADATA_BSF)     += h264_levels
+@@ -1343,6 +1343,7 @@ TESTPROGS-$(CONFIG_H264_METADATA_BSF)     += h264_levels
  TESTPROGS-$(CONFIG_HEVC_METADATA_BSF)     += h265_levels
  TESTPROGS-$(CONFIG_RANGECODER)            += rangecoder
  TESTPROGS-$(CONFIG_SNOW_ENCODER)          += snowenc
@@ -202,10 +202,10 @@ index 2acfc4e804..5e0ccc5838 100644
  /avpacket
 diff --git a/libavcodec/tests/av1_levels.c b/libavcodec/tests/av1_levels.c
 new file mode 100644
-index 0000000000..8a980d42c1
+index 0000000000..b308279b58
 --- /dev/null
 +++ b/libavcodec/tests/av1_levels.c
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,125 @@
 +/*
 + * Copyright (c) 2022 Fei Wang
 + *
@@ -227,6 +227,7 @@ index 0000000000..8a980d42c1
 + */
 +
 +#include "libavutil/common.h"
++#include "libavutil/log.h"
 +#include "libavcodec/av1_profile_level.h"
 +
 +static const struct {
@@ -347,5 +348,5 @@ index 8f56fae3a8..95efa6ccda 100644
  fate-iirfilter: libavcodec/tests/iirfilter$(EXESUF)
  fate-iirfilter: CMD = run libavcodec/tests/iirfilter$(EXESUF)
 -- 
-2.25.1
+2.34.1
 

--- a/patches/0101-lavc-vaapi_encode-Add-VAAPI-AV1-encoder.patch
+++ b/patches/0101-lavc-vaapi_encode-Add-VAAPI-AV1-encoder.patch
@@ -1,7 +1,7 @@
-From 01ff869e0a53757b48a4de7ef8503f38e2ce60bb Mon Sep 17 00:00:00 2001
+From f204119ca44023f1453aa66d2b6dde1925202068 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Sun, 23 Apr 2023 16:23:06 +0800
-Subject: [PATCH] lavc/vaapi_encode: Add VAAPI AV1 encoder
+Subject: [PATCH 39/40] lavc/vaapi_encode: Add VAAPI AV1 encoder
 
 Signed-off-by: Fei Wang <fei.w.wang@intel.com>
 ---
@@ -16,10 +16,10 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  create mode 100644 libavcodec/vaapi_encode_av1.c
 
 diff --git a/configure b/configure
-index bc0961a0bb..cc2609ae0f 100755
+index b0b853b19e..1eee7c8448 100755
 --- a/configure
 +++ b/configure
-@@ -3340,6 +3340,8 @@ av1_qsv_decoder_select="qsvdec"
+@@ -3344,6 +3344,8 @@ av1_qsv_decoder_select="qsvdec"
  av1_qsv_encoder_select="qsvenc"
  av1_qsv_encoder_deps="libvpl"
  av1_amf_encoder_deps="amf"
@@ -28,7 +28,7 @@ index bc0961a0bb..cc2609ae0f 100755
  
  # parsers
  aac_parser_select="adts_header mpeg4audio"
-@@ -7126,6 +7128,7 @@ if enabled vaapi; then
+@@ -7138,6 +7140,7 @@ if enabled vaapi; then
      check_type "va/va.h va/va_enc_jpeg.h" "VAEncPictureParameterBufferJPEG"
      check_type "va/va.h va/va_enc_vp8.h"  "VAEncPictureParameterBufferVP8"
      check_type "va/va.h va/va_enc_vp9.h"  "VAEncPictureParameterBufferVP9"
@@ -37,10 +37,10 @@ index bc0961a0bb..cc2609ae0f 100755
  
  if enabled_all opencl libdrm ; then
 diff --git a/doc/encoders.texi b/doc/encoders.texi
-index 20cb8a1421..def1efa0ef 100644
+index 6f8f5e127e..8adef7fb88 100644
 --- a/doc/encoders.texi
 +++ b/doc/encoders.texi
-@@ -3977,6 +3977,20 @@ Average variable bitrate.
+@@ -3995,6 +3995,20 @@ Average variable bitrate.
  Each encoder also has its own specific options:
  @table @option
  
@@ -62,10 +62,10 @@ index 20cb8a1421..def1efa0ef 100644
  @option{profile} sets the value of @emph{profile_idc} and the @emph{constraint_set*_flag}s.
  @option{level} sets the value of @emph{level_idc}.
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index cc46cd7867..86d1e240fc 100644
+index 02c84d5f33..0ed173f886 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -257,6 +257,7 @@ OBJS-$(CONFIG_AV1_MEDIACODEC_DECODER)  += mediacodecdec.o
+@@ -258,6 +258,7 @@ OBJS-$(CONFIG_AV1_MEDIACODEC_DECODER)  += mediacodecdec.o
  OBJS-$(CONFIG_AV1_MEDIACODEC_ENCODER)  += mediacodecenc.o
  OBJS-$(CONFIG_AV1_NVENC_ENCODER)       += nvenc_av1.o nvenc.o
  OBJS-$(CONFIG_AV1_QSV_ENCODER)         += qsvenc_av1.o
@@ -74,10 +74,10 @@ index cc46cd7867..86d1e240fc 100644
  OBJS-$(CONFIG_AVRP_DECODER)            += r210dec.o
  OBJS-$(CONFIG_AVRP_ENCODER)            += r210enc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 11c136ef59..9f3b557f9b 100644
+index 6e95ca5636..5136a566f1 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -843,6 +843,7 @@ extern const FFCodec ff_av1_nvenc_encoder;
+@@ -845,6 +845,7 @@ extern const FFCodec ff_av1_nvenc_encoder;
  extern const FFCodec ff_av1_qsv_decoder;
  extern const FFCodec ff_av1_qsv_encoder;
  extern const FFCodec ff_av1_amf_encoder;
@@ -86,7 +86,7 @@ index 11c136ef59..9f3b557f9b 100644
  extern const FFCodec ff_libopenh264_decoder;
  extern const FFCodec ff_h264_amf_encoder;
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 045f3cf525..7aa82d94a0 100644
+index 71b8398d6e..9abfc5f987 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -656,6 +656,11 @@ static int vaapi_encode_set_output_timestamp(AVCodecContext *avctx,
@@ -277,7 +277,7 @@ index 045f3cf525..7aa82d94a0 100644
  
      av_buffer_unref(&ctx->recon_frames_ref);
 diff --git a/libavcodec/vaapi_encode.h b/libavcodec/vaapi_encode.h
-index a1e639f56b..b3709dcf91 100644
+index bd25cd5c95..7d8b78927d 100644
 --- a/libavcodec/vaapi_encode.h
 +++ b/libavcodec/vaapi_encode.h
 @@ -131,6 +131,11 @@ typedef struct VAAPIEncodePicture {
@@ -308,7 +308,7 @@ index a1e639f56b..b3709dcf91 100644
  enum {
 diff --git a/libavcodec/vaapi_encode_av1.c b/libavcodec/vaapi_encode_av1.c
 new file mode 100644
-index 0000000000..4a9b72453c
+index 0000000000..248563761f
 --- /dev/null
 +++ b/libavcodec/vaapi_encode_av1.c
 @@ -0,0 +1,1246 @@
@@ -1345,9 +1345,9 @@ index 0000000000..4a9b72453c
 +}
 +
 +static const VAAPIEncodeProfile vaapi_encode_av1_profiles[] = {
-+    { FF_PROFILE_AV1_MAIN,  8, 3, 1, 1, VAProfileAV1Profile0 },
-+    { FF_PROFILE_AV1_MAIN, 10, 3, 1, 1, VAProfileAV1Profile0 },
-+    { FF_PROFILE_UNKNOWN }
++    { AV_PROFILE_AV1_MAIN,  8, 3, 1, 1, VAProfileAV1Profile0 },
++    { AV_PROFILE_AV1_MAIN, 10, 3, 1, 1, VAProfileAV1Profile0 },
++    { AV_PROFILE_UNKNOWN }
 +};
 +
 +static const VAAPIEncodeType vaapi_encode_type_av1 = {
@@ -1386,7 +1386,7 @@ index 0000000000..4a9b72453c
 +        VA_ENC_PACKED_HEADER_SEQUENCE |
 +        VA_ENC_PACKED_HEADER_PICTURE;
 +
-+    if (avctx->profile == FF_PROFILE_UNKNOWN)
++    if (avctx->profile == AV_PROFILE_UNKNOWN)
 +        avctx->profile = priv->profile;
 +    if (avctx->level == FF_LEVEL_UNKNOWN)
 +        avctx->level = priv->level;
@@ -1473,13 +1473,13 @@ index 0000000000..4a9b72453c
 +    VAAPI_ENCODE_RC_OPTIONS,
 +    { "profile", "Set profile (seq_profile)",
 +      OFFSET(profile), AV_OPT_TYPE_INT,
-+      { .i64 = FF_PROFILE_UNKNOWN }, FF_PROFILE_UNKNOWN, 0xff, FLAGS, "profile" },
++      { .i64 = AV_PROFILE_UNKNOWN }, AV_PROFILE_UNKNOWN, 0xff, FLAGS, "profile" },
 +
 +#define PROFILE(name, value)  name, NULL, 0, AV_OPT_TYPE_CONST, \
 +    { .i64 = value }, 0, 0, FLAGS, "profile"
-+    { PROFILE("main",               FF_PROFILE_AV1_MAIN) },
-+    { PROFILE("high",               FF_PROFILE_AV1_HIGH) },
-+    { PROFILE("professional",       FF_PROFILE_AV1_PROFESSIONAL) },
++    { PROFILE("main",               AV_PROFILE_AV1_MAIN) },
++    { PROFILE("high",               AV_PROFILE_AV1_HIGH) },
++    { PROFILE("professional",       AV_PROFILE_AV1_PROFESSIONAL) },
 +#undef PROFILE
 +
 +    { "tier", "Set tier (seq_tier)",
@@ -1559,5 +1559,5 @@ index 0000000000..4a9b72453c
 +    .p.wrapper_name = "vaapi",
 +};
 -- 
-2.25.1
+2.34.1
 


### PR DESCRIPTION
Submodule ffmpeg bfa43447fa..398467f519

Update 0034, 0086, 0087, 0088, 0091 and 0101

Note FF_PROFILE_* were deprecated recently, instead AV_PROFILE_* are used now.